### PR TITLE
Fix text wrapping

### DIFF
--- a/src/Browser.js
+++ b/src/Browser.js
@@ -115,17 +115,7 @@ const Browser = (props) => {
   <div className="max-w-md w-full space-y-12">
     <div>
       <SVG lightTheme={lightTheme} />
-      <h2 className="mt-6 text-center text-2xl font-extrabold text-gray-900 dark:text-white">
-        <span className="nowrap">
-          Browse <span className="text-purple-600">privately</span>.
-        </span>&nbsp;
-        <span className="nowrap">
-          Browse <span className="text-purple-600">together</span>.
-        </span>&nbsp;
-        <span >
-          Browse <span className="text-purple-600">faster</span>.
-        </span>
-      </h2>
+      <h2 className="mt-6 text-center text-2xl font-extrabold text-gray-900 dark:text-white"><span class="nowrap">Browse <span class="text-purple-600">privately</span></span>. <span class="nowrap">Browse <span class="text-purple-600">together</span></span>. <span class="nowrap">Browse <span class="text-purple-600">faster</span></span>.</h2>
       <p className="mt-2 text-center text-sm text-gray-600 dark:text-white">
         Start web browsing now as a team by setting up a co-browsing session
         below.

--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.nowrap {
+  white-space: nowrap;
+}


### PR DESCRIPTION
Note that it's not possible to keep class `text-2xl` for the subheading text (i.e. Browse privately. Browse together. Browse faster.) and have it all it on the same line with no text wrapping. Either reduce the font size or increase available width.

Screenshots:
![localhost_3000_ (1)](https://user-images.githubusercontent.com/6129517/133673463-73d2cfb4-7dcd-4cc7-b19d-958d9852d6be.png)
![localhost_3000_](https://user-images.githubusercontent.com/6129517/133673264-98d412cb-9af1-429e-9e06-f9eaa9ca5a3e.png)


